### PR TITLE
[0001/initial] 初期実装

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,0 +1,46 @@
+body {
+  background-color: #ccccff;
+  width: 100%;
+  text-align: center;
+  font-family: "Segoe UI", "Yu Gothic", sans-serif, ;
+}
+
+#content {
+  width: 80%;
+  text-align: left;
+  margin: 0 10%;
+  box-sizing: border-box;
+}
+
+p {
+  width: 100%;
+}
+
+textarea {
+  width: 100%;
+  height: 8em;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: #0000ff;
+  border-width: 1.5px;
+}
+
+.common_button {
+  width: 20%;
+  height: 2em;
+  margin-right: 5%;
+}
+
+.text-score-no {
+  width: 5%;
+}
+
+.text-first-num {
+  width: 10%;
+}
+
+.text-tempo {
+  width: 20%;
+}

--- a/index.html
+++ b/index.html
@@ -34,13 +34,23 @@
         <option value="17">17</option>
       </select>
 
-      <label for="scoreNo">譜面番号: </label>
+      / <label for="scoreNo">譜面番号: </label>
       <input type="text" id="scoreNo" name="scoreNo" placeholder="1" value="" class="text-score-no" />
+
+      / <label for="rhythm">拍子: </label>
+      <select id="rhythm" name="rhythm">
+        <option value="2">4</option>
+        <option value="3">3</option>
+        <option value="5">5</option>
+        <option value="7">7</option>
+      </select>
 
       <br>
       <label for="separator">区切り文字: </label>
-      <input type="radio" name="separator" value="amp" checked="checked"> "&amp;"もしくは"|"　
-      <input type="radio" name="separator" value="pipe"> "|"のみ
+      <select id="separator" name="separator">
+        <option value="amp">"&amp;"もしくは"|"</option>
+        <option value="pipe">"|"のみ</option>
+      </select>
 
       <br>
       譜面基礎情報 (テンポ変化ごとにカンマ区切り)：<br>　

--- a/index.html
+++ b/index.html
@@ -55,18 +55,18 @@
       <br>
       譜面基礎情報 (テンポ変化ごとにカンマ区切り)：<br>　
       <label for="firstNum">ファーストナンバー: </label>
-      <input type="text" id="firstNum" name="firstNum" placeholder="200" value="" class="text-first-num" />
+      <input type="text" id="firstNum" name="firstNum" value="" class="text-first-num" />
 
       / <label for="interval">BPM: </label>
-      <input type="text" id="bpm" name="bpm" placeholder="180" value="" class="text-first-num" />
+      <input type="text" id="bpm" name="bpm" value="" class="text-first-num" />
       <button type="button" onclick="bpmToInterval()">Convert</button>
 
       / <label for="interval">4分間隔: </label>
-      <input type="text" id="interval" name="interval" placeholder="10" value="" class="text-first-num" />
+      <input type="text" id="interval" name="interval" value="" class="text-first-num" />
 
       <br>　
       <label for="interval">テンポ変化ページ: </label>
-      <input type="text" id="tempo" name="tempo" placeholder="0" value="" class="text-tempo" />
+      <input type="text" id="tempo" name="tempo" value="" class="text-tempo" />
       <br>
       <label for="editor">変換先エディター: </label>
       <select id="editor" name="editor">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
 </head>
 
 <body>
-  <h1>Dancing☆Onigiri ChartReverser<br>(セーブデータ復元ツール)</h1>
+  <h1>Dancing☆Onigiri ChartReverser</h1>
+  <span id="version"></span>
   <hr />
   <div id="content">
     <p>
@@ -80,8 +81,7 @@
       </div>
       <button type="button" onclick="convert()" class="common_button">Convert</button>
       <input type="reset" value="Reset" class="common_button" />
-      <div>↓</div>
-      <p>変換後データ</p>
+      <div>↓<br>変換後データ</div>
       <div>
         <textarea id="output-save-data" readonly></textarea>
       </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+﻿<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="css/main.css" />
+  <title>Dancing☆Onigiri ChartReverser (セーブデータ復元ツール)</title>
+</head>
+
+<body>
+  <h1>Dancing☆Onigiri ChartReverser<br>(セーブデータ復元ツール)</h1>
+  <hr />
+  <div id="content">
+    <p>
+      Dancing☆Onigiriの譜面データを各種エディターのセーブデータに変換します。<br>
+      変換するデータを入力してください。<br>
+    </p>
+    <form>
+      <label for="keys">キー数: </label>
+      <select id="keys" name="keys">
+        <option value="5">5</option>
+        <option value="7">7</option>
+        <option value="7i">7i</option>
+        <option value="9">9A(DP)/9B</option>
+        <option value="11">8/11/11L</option>
+        <option value="11i">11i</option>
+        <option value="12">12</option>
+        <option value="13">13(TP)</option>
+        <option value="14">14</option>
+        <option value="14i">14i</option>
+        <option value="15">15A/15B</option>
+        <option value="16i">16i</option>
+        <option value="17">17</option>
+      </select>
+
+      <label for="scoreNo">譜面番号: </label>
+      <input type="text" id="scoreNo" name="scoreNo" placeholder="1" value="" class="text-score-no" />
+
+      <br>
+      <label for="separator">区切り文字: </label>
+      <input type="radio" name="separator" value="amp" checked="checked"> "&amp;"もしくは"|"　
+      <input type="radio" name="separator" value="pipe"> "|"のみ
+
+      <br>
+      譜面基礎情報 (テンポ変化ごとにカンマ区切り)：<br>　
+      <label for="firstNum">ファーストナンバー: </label>
+      <input type="text" id="firstNum" name="firstNum" placeholder="200" value="" class="text-first-num" />
+
+      / <label for="interval">BPM: </label>
+      <input type="text" id="bpm" name="bpm" placeholder="180" value="" class="text-first-num" />
+      <button type="button" onclick="bpmToInterval()">Convert</button>
+
+      / <label for="interval">4分間隔: </label>
+      <input type="text" id="interval" name="interval" placeholder="10" value="" class="text-first-num" />
+
+      <br>　
+      <label for="interval">テンポ変化ページ: </label>
+      <input type="text" id="tempo" name="tempo" placeholder="0,2" value="" class="text-tempo" />
+      <br>
+      <label for="editor">変換先エディター: </label>
+      <input type="radio" name="editor" value="tickle" checked="checked"> tickle (Cross Walker)
+      <input type="radio" name="editor" value="doyle"> Doyle (変速式)
+      <input type="radio" name="editor" value="fuji"> FUJI (気分転換にRPG)
+
+      <div>
+        <textarea id="input-dos-data"></textarea>
+      </div>
+      <button type="button" onclick="convert()" class="common_button">Convert</button>
+      <input type="reset" value="Reset" class="common_button" />
+      <div>↓</div>
+      <p>変換後データ</p>
+      <div>
+        <textarea id="output-save-data" readonly></textarea>
+      </div>
+      <button type="button" onclick="copy()" class="common_button">Copy</button>
+    </form>
+  </div>
+  <hr />
+</body>
+<script type="text/javascript" src="js/main.js"></script>
+<script>
+  function convert() {
+    const baseStr = document.getElementById("input-dos-data").value;
+    const saveData = makeSaveData(baseStr);
+    document.getElementById("output-save-data").value = saveData;
+  }
+
+  function copy() {
+    const saveData = document.getElementById("output-save-data").value;
+    navigator.clipboard.writeText(saveData);
+  }
+</script>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       <br>
       <label for="editor">変換先エディター: </label>
       <input type="radio" name="editor" value="tickle" checked="checked"> tickle (Cross Walker)
-      <input type="radio" name="editor" value="doyle"> Doyle (変速式)
+      <input type="radio" name="editor" value="doyle"> Doyle (SPEED START)
       <input type="radio" name="editor" value="fuji"> FUJI (気分転換にRPG)
 
       <div>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <option value="7">7</option>
         <option value="7i">7i</option>
         <option value="9">9A(DP)/9B</option>
-        <option value="11">8/11/11L</option>
+        <option value="11">8/11/11L/11W</option>
         <option value="11i">11i</option>
         <option value="12">12</option>
         <option value="13">13(TP)</option>
@@ -56,12 +56,14 @@
 
       <br>　
       <label for="interval">テンポ変化ページ: </label>
-      <input type="text" id="tempo" name="tempo" placeholder="0,2" value="" class="text-tempo" />
+      <input type="text" id="tempo" name="tempo" placeholder="0" value="" class="text-tempo" />
       <br>
       <label for="editor">変換先エディター: </label>
-      <input type="radio" name="editor" value="tickle" checked="checked"> tickle (Cross Walker)
-      <input type="radio" name="editor" value="doyle"> Doyle (SPEED START)
-      <input type="radio" name="editor" value="fuji"> FUJI (気分転換にRPG)
+      <select id="editor" name="editor">
+        <option value="tickle">tickle (Cross Walker)</option>
+        <option value="doyle">Doyle (SPEED START)</option>
+        <option value="fuji">FUJI (気分転換にRPG)</option>
+      </select>
 
       <div>
         <textarea id="input-dos-data"></textarea>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,186 @@
+`use strict`;
+/**
+ * Dancing☆Onigiri (CW Edition) 
+ * ChartReverser
+ *
+ * Source by tickle
+ * Created : 2020/09/09
+ * Revised : 
+ *
+ * https://github.com/cwtickle/danoniplus-reverser
+ */
+const g_version = `Ver 0.1.0`;
+
+let g_rootObj = {};
+const g_keyObj = {
+
+    // キー別ヘッダー
+    // - 譜面データ中に出てくる矢印(ノーツ)の種類と順番(ステップゾーン表示順)を管理する。
+    // - ここで出てくる順番は、この後のstepRtn, keyCtrlとも対応している。 
+    chara5_0: [`left`, `down`, `up`, `right`, `space`],
+    chara7_0: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara7i_0: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara8_0: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`, `sleft`],
+    chara9A_0: [`left`, `down`, `up`, `right`, `space`, `sleft`, `sdown`, `sup`, `sright`],
+    chara9B_0: [`left`, `down`, `up`, `right`, `space`, `sleft`, `sdown`, `sup`, `sright`],
+    chara9i_0: [`sleft`, `sdown`, `sup`, `sright`, `left`, `down`, `up`, `right`, `space`],
+    chara11_0: [`sleft`, `sdown`, `sup`, `sright`,
+        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara11L_0: [`sleft`, `sdown`, `sup`, `sright`,
+        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara11i_0: [`left`, `down`, `gor`, `up`, `right`, `space`,
+        `sleft`, `sdown`, `siyo`, `sup`, `sright`],
+    chara11W_0: [`sleft`, `sdown`, `sup`, `sright`,
+        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara12_0: [`sleft`, `sdown`, `sup`, `sright`,
+        `oni`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara13_0: [`tleft`, `tdown`, `tup`, `tright`,
+        `left`, `down`, `up`, `right`, `space`, `sleft`, `sdown`, `sup`, `sright`],
+    chara14_0: [`sleftdia`, `sleft`, `sdown`, `sup`, `sright`, `srightdia`,
+        `oni`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara14i_0: [`gor`, `space`, `iyo`, `left`, `down`, `up`, `right`,
+        `sleft`, `sleftdia`, `sdown`, `sspace`, `sup`, `srightdia`, `sright`],
+    chara15A_0: [`sleft`, `sdown`, `sup`, `sright`, `tleft`, `tdown`, `tup`, `tright`,
+        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara15B_0: [`sleft`, `sdown`, `sup`, `sright`, `tleft`, `tdown`, `tup`, `tright`,
+        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara16i_0: [`gor`, `space`, `iyo`, `left`, `down`, `up`, `right`,
+        `sleft`, `sdown`, `sup`, `sright`, `aspace`, `aleft`, `adown`, `aup`, `aright`],
+    chara17_0: [`aleft`, `bleft`, `adown`, `bdown`, `aup`, `bup`, `aright`, `bright`, `space`,
+        `cleft`, `dleft`, `cdown`, `ddown`, `cup`, `dup`, `cright`, `dright`],
+};
+
+/**
+ * BPMからIntervalへ変換
+ */
+const bpmToInterval = () => {
+    const bpms = document.getElementById(`bpm`).value;
+    if (bpms === ``) return;
+
+    let intervals = [];
+    bpms.split(`,`).forEach(bpm => {
+        intervals.push(1800 / bpm);
+    });
+    document.getElementById(`interval`).value = intervals.join(`,`);
+    return intervals.join(`,`);
+}
+
+/**
+ * 先頭文字を大文字化
+ * @param {string} _str 
+ */
+const toCapitalize = (_str) => {
+    if (!_str || typeof _str !== `string`) return _str;
+    return `${_str.charAt(0).toUpperCase()}${_str.slice(1)}`;
+}
+
+/**
+ * 単発矢印の名前からフリーズアローの名前へ変換
+ * @param {array} _array 
+ */
+const createFrzHeader = (_array) => {
+
+    let frzNames = [];
+    _array.forEach(name => {
+
+        let frzName = name.replace(`leftdia`, `frzLdia`)
+            .replace(`rightdia`, `frzRdia`)
+            .replace(`left`, `frzLeft`)
+            .replace(`down`, `frzDown`)
+            .replace(`up`, `frzUp`)
+            .replace(`right`, `frzRight`)
+            .replace(`space`, `frzSpace`)
+            .replace(`iyo`, `frzIyo`)
+            .replace(`gor`, `frzGor`)
+            .replace(`oni`, `foni`);
+
+        if (frzName.indexOf(`frz`) === -1 && frzName.indexOf(`foni`) === -1) {
+            if ((frzName.startsWith(`s`)) || frzName.startsWith(`t`) ||
+                (frzName.startsWith(`a`) && !frzName.startsWith(`arrow`))) {
+                frzName = frzName.replace(frzName.slice(1), `frz${toCapitalize(frzName.slice(1))}`);
+            } else {
+                frzName = frzName.replace(frzName, `frz${toCapitalize(frzName)}`);
+            }
+        }
+        frzNames.push(frzName);
+    });
+
+    return frzNames;
+}
+
+/**
+ * 入力データを区切り文字を元に分解して、オブジェクト化
+ * @param {string} _dos 
+ */
+const rawDosToObject = (_dos) => {
+
+    const obj = {};
+    const paramsTmp = document.getElementById(`separator`) === `amp` ? _dos.split(`&`).join(`|`) : _dos;
+    const params = paramsTmp.split(`|`);
+    for (let j = 0; j < params.length; j++) {
+        const pos = params[j].indexOf(`=`);
+        if (pos > 0) {
+            const pKey = params[j].substring(0, pos);
+            const pValue = params[j].substring(pos + 1);
+
+            if (pKey !== undefined) {
+                obj[pKey] = pValue;
+            }
+        }
+    }
+    return obj;
+}
+
+/**
+ * 譜面データを数字毎に分解して、名称別のオブジェクトへ格納
+ * @param {array} _names 
+ * @param {string} _scoreNo 
+ * @param {number} _keyNum 
+ */
+const createBaseData = (_names, _scoreNo, _keyNum) => {
+
+    let baseData = {};
+    _names.forEach(name => {
+        if (g_rootObj[`${name}${_scoreNo}_data`] !== undefined) {
+            baseData[name] = (g_rootObj[`${name}${_scoreNo}_data`].split(`,`));
+        }
+    });
+
+    // speedX_change があれば、speedX_data と置き換える（例外処理）
+    if (g_rootObj[`speed${_scoreNo}_change`] !== undefined) {
+        baseData.speed = g_rootObj[`speed${_scoreNo}_change`].split(`,`);
+    }
+    return baseData;
+}
+
+/**
+ * セーブデータ生成処理（メイン）
+ * @param {string} _str 
+ */
+const makeSaveData = (_str) => {
+
+    // Interval未指定の場合はBPM値から取得
+    let intervals = document.getElementById(`interval`).value;
+    if (intervals === ``) {
+        intervals = bpmToInterval();
+    }
+
+    // キー数及び譜面データ名の取得
+    const keyLabel = document.getElementById(`keys`).value;
+    const arrowNames = g_keyObj[`chara${keyLabel}_0`].concat();
+    const frzNames = createFrzHeader(arrowNames);
+
+    const keyNum = arrowNames.length;
+    const keyNames = arrowNames.concat(frzNames, [`speed`, `boost`]);
+
+    const tmpScoreNo = document.getElementById(`scoreNo`).value;
+    const scoreNo = tmpScoreNo === `1` ? `` : tmpScoreNo;
+
+    // 入力データを分解してオブジェクト化
+    g_rootObj = rawDosToObject(_str);
+
+    const baseData = createBaseData(keyNames, scoreNo, keyNum);
+
+    console.log(baseData);
+
+}

--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,10 @@
  *
  * https://github.com/cwtickle/danoniplus-reverser
  */
-const g_version = `Ver 0.12.1`;
+const g_version = `Ver 0.12.2`;
+
+// バージョン名の表記
+document.getElementById(`version`).innerHTML = `(${g_version})`;
 
 let g_rootObj = {};
 let g_paramObj = {};

--- a/js/main.js
+++ b/js/main.js
@@ -240,6 +240,56 @@ const setParameters = (_names, _baseData) => {
 }
 
 /**
+ * エディター上の位置を計算
+ * @param {array} _names 
+ * @param {object} _baseData 
+ */
+const calcPoint = (_names, _baseData) => {
+
+    let maxPage = 200;
+    let currentPos = {};
+    let saveBaseData = {};
+    const keyNames = _names.concat([`speedFrame`, `boostFrame`]);
+    keyNames.forEach(name => {
+
+        if (_baseData[name] === undefined) {
+            return;
+        }
+        currentPos[name] = 0;
+        saveBaseData[name] = [];
+
+        for (let j = 0; j < g_paramObj.firstNums.length; j++) {
+            const nextFirst = (j === g_paramObj.firstNums.length - 1 ? Infinity : g_paramObj.firstNums[j + 1]);
+            const currentFirst = g_paramObj.firstNums[j];
+            const currentInterval = (g_paramObj.intervals[j] !== undefined ? g_paramObj.intervals[j] : 10);
+            const currentTempo = (g_paramObj.tempos[j] !== undefined ? g_paramObj.tempos[j] : maxPage);
+
+            for (let k = currentPos[name]; k < _baseData[name].length; k++) {
+                const num = _baseData[name][k];
+                if (nextFirst - num > 0) {
+                    saveBaseData[name].push(Math.round((num - currentFirst) / (currentInterval / 2)) + currentTempo * 64);
+                    currentPos[name]++;
+                } else {
+                    const currentMaxPage = Math.ceil(saveBaseData[name][saveBaseData[name].length - 1]) / 64;
+                    if (currentMaxPage > maxPage) {
+                        maxPage = currentMaxPage;
+                    }
+                    break;
+                }
+            }
+
+            const currentMaxPage = Math.ceil(saveBaseData[name][saveBaseData[name].length - 1]) / 64;
+            if (currentMaxPage > maxPage) {
+                maxPage = currentMaxPage;
+            }
+        }
+    });
+
+    console.log(saveBaseData);
+
+}
+
+/**
  * セーブデータ生成処理（メイン）
  * @param {string} _str 
  */
@@ -263,5 +313,7 @@ const makeSaveData = (_str) => {
     console.log(baseData);
 
     setParameters(keyNames, baseData);
+
+    calcPoint(keyNames, baseData);
 
 }

--- a/js/main.js
+++ b/js/main.js
@@ -197,15 +197,44 @@ const getFirstNum = (_names, _baseData) => {
  * @param {object} _baseData 
  * @param {string} _intervals 
  */
-const setParameters = (_names, _baseData, _intervals) => {
+const setParameters = (_names, _baseData) => {
 
+    // ファーストナンバーの取得
     const firstNums = document.getElementById(`firstNum`).value;
-    if (firstNums === ``) {
-        g_paramObj.firstNums = [getFirstNum(_names, _baseData)];
-    } else {
+    if (g_rootObj.first_num !== undefined) {
+        g_paramObj.firstNums = g_rootObj.first_num.split(`,`);
+    } else if (firstNums !== ``) {
         g_paramObj.firstNums = firstNums.split(`,`);
+    } else {
+        g_paramObj.firstNums = [getFirstNum(_names, _baseData)];
     }
-    console.log(g_paramObj.firstNums);
+    document.getElementById(`firstNum`).value = g_paramObj.firstNums.join(`,`);
+
+    // Intervalの取得
+    const intervals = document.getElementById(`interval`).value;
+    if (g_rootObj.haba_num !== undefined) {
+        g_paramObj.intervals = g_rootObj.haba_num.split(`,`);
+    } else if (intervals !== ``) {
+        g_paramObj.intervals = intervals.split(`,`);
+    } else {
+        const tmpIntervals = bpmToInterval();
+        g_paramObj.intervals = (tmpIntervals !== undefined ? tmpIntervals.split(`,`) : [10]);
+    }
+    document.getElementById(`interval`).value = g_paramObj.intervals.join(`,`);
+
+    // BPMの取得
+    g_paramObj.bpms = g_paramObj.intervals.map(interval => 1800 / interval);
+    document.getElementById(`bpm`).value = g_paramObj.bpms.join(`,`);
+
+    // テンポ変化位置の取得
+    const tempos = document.getElementById(`tempo`).value;
+    if (g_rootObj.haba_page_num !== undefined) {
+        g_paramObj.tempos = g_rootObj.haba_page_num.split(`,`);
+    } else {
+        g_paramObj.tempos = (tempos !== `` ? tempos.split(`,`) : [0]);
+    }
+
+    console.log(g_paramObj);
 }
 
 /**
@@ -213,12 +242,6 @@ const setParameters = (_names, _baseData, _intervals) => {
  * @param {string} _str 
  */
 const makeSaveData = (_str) => {
-
-    // Interval未指定の場合はBPM値から取得
-    let intervals = document.getElementById(`interval`).value;
-    if (intervals === ``) {
-        intervals = bpmToInterval();
-    }
 
     // キー数及び譜面データ名の取得
     const keyLabel = document.getElementById(`keys`).value;
@@ -237,6 +260,6 @@ const makeSaveData = (_str) => {
 
     console.log(baseData);
 
-    setParameters(keyNames, baseData, intervals);
+    setParameters(keyNames, baseData);
 
 }

--- a/js/main.js
+++ b/js/main.js
@@ -229,7 +229,7 @@ const setParameters = (_names, _baseData) => {
     // ファーストナンバーの取得
     const firstNums = document.getElementById(`firstNum`).value;
     if (g_rootObj.first_num !== undefined) {
-        g_paramObj.firstNums = g_rootObj.first_num.split(`,`);
+        g_paramObj.firstNums = g_rootObj.first_num.split(`,`).map(data => parseFloat(data));
     } else if (firstNums !== ``) {
         g_paramObj.firstNums = firstNums.split(`,`);
     } else {
@@ -240,7 +240,7 @@ const setParameters = (_names, _baseData) => {
     // Intervalの取得
     const intervals = document.getElementById(`interval`).value;
     if (g_rootObj.haba_num !== undefined) {
-        g_paramObj.intervals = g_rootObj.haba_num.split(`,`);
+        g_paramObj.intervals = g_rootObj.haba_num.split(`,`).map(data => parseFloat(data));
     } else if (intervals !== ``) {
         g_paramObj.intervals = intervals.split(`,`);
     } else {
@@ -256,7 +256,7 @@ const setParameters = (_names, _baseData) => {
     // テンポ変化位置の取得
     const tempos = document.getElementById(`tempo`).value;
     if (g_rootObj.haba_page_num !== undefined) {
-        g_paramObj.tempos = g_rootObj.haba_page_num.split(`,`);
+        g_paramObj.tempos = g_rootObj.haba_page_num.split(`,`).map(data => parseFloat(data));
     } else {
         g_paramObj.tempos = (tempos !== `` ? tempos.split(`,`) : [0]);
     }
@@ -265,7 +265,7 @@ const setParameters = (_names, _baseData) => {
     // 拍子データの取得
     const rhythm = parseFloat(document.getElementById(`rhythm`).value);
     if (g_rootObj.beat_num !== undefined) {
-        g_paramObj.rhythm = parseFloat(g_rootObj.beat_num);
+        g_paramObj.rhythm = parseFloat(g_rootObj.beat_num === `4` ? `2` : g_rootObj.beat_num);
     } else {
         g_paramObj.rhythm = rhythm;
     }
@@ -356,13 +356,36 @@ const printFuji2 = (_keys, _names, _saveData, _baseData, _scoreNo, _lastNums, _m
 
     saveData += `\r\n;===以下譜面\r\n`;
 
-    // 小節部:00～15, 矢印部:0～6, 調整部:1桁
+    let editorData = [];
+    _names.forEach((name, i) => {
 
-    // 譜面(矢印出力)
+        if (_saveData[name] === undefined) {
+            return;
+        }
+        if (i < _names.length / 2) {
+            // 小節部:00～15, 矢印部:0～6, 調整部:1桁
+            // 譜面(矢印出力)
+            _saveData[name].forEach(koma => {
+                if (editorData[koma] === undefined) {
+                    editorData[koma] = [];
+                }
+                editorData[koma].push(`${(koma % 16).toString(16)}${i.toString(36)}0`);
+            });
+        } else {
+            // フリーズ開始：小節部:00～15, 矢印部:0～6, 調整部:1桁(開始Def:5)
+            // 譜面(フリーズアロー出力)
+            const frzStarts = getOddEvenArray(_saveData[name], 1);
+            const frzEnds = getOddEvenArray(_saveData[name], 2);
+            frzStarts.forEach((koma, i) => {
+                if (editorData[koma] === undefined) {
+                    editorData[koma] = [];
+                }
+                editorData[koma].push(`${(koma % 16).toString(16)}${i.toString(36)}0+${String(frzEnds[i] - koma).padStart(3, '0')}`);
+            })
+        }
+    });
 
-    // フリーズ開始：小節部:00～15, 矢印部:0～6, 調整部:1桁(開始Def:5)
-
-    // 譜面(フリーズアロー出力)
+    console.log(editorData);
 
 };
 

--- a/js/main.js
+++ b/js/main.js
@@ -44,6 +44,16 @@ const g_keyObj = {
 };
 
 /**
+ * 拍子別の小節数 (4拍子のみ例外的に2を指定)
+ */
+const g_measure = {
+    2: 16,
+    3: 15,
+    5: 15,
+    7: 14,
+};
+
+/**
  * BPMからIntervalへ変換
  */
 const bpmToInterval = () => {
@@ -108,7 +118,7 @@ const createFrzHeader = (_array) => {
 const rawDosToObject = (_dos) => {
 
     const obj = {};
-    const paramsTmp = document.getElementById(`separator`) === `amp` ? _dos.split(`&`).join(`|`) : _dos;
+    const paramsTmp = document.getElementById(`separator`).value === `amp` ? _dos.split(`&`).join(`|`) : _dos;
     const params = paramsTmp.split(`|`);
     for (let j = 0; j < params.length; j++) {
         const pos = params[j].indexOf(`=`);
@@ -228,6 +238,15 @@ const setParameters = (_names, _baseData) => {
     }
     document.getElementById(`tempo`).value = g_paramObj.tempos.join(`,`);
 
+    // 拍子データの取得
+    const rhythm = parseFloat(document.getElementById(`rhythm`).value);
+    if (g_rootObj.beat_num !== undefined) {
+        g_paramObj.rhythm = parseFloat(g_rootObj.beat_num);
+    } else {
+        g_paramObj.rhythm = rhythm;
+    }
+    document.getElementById(`rhythm`).value = g_paramObj.rhythm;
+
     console.log(g_paramObj);
 }
 
@@ -261,10 +280,11 @@ const calcPoint = (_names, _baseData) => {
             for (let k = currentPos[name]; k < _baseData[name].length; k++) {
                 const num = _baseData[name][k];
                 if (nextFirst - num > 0) {
-                    saveBaseData[name].push(Math.round((num - currentFirst) / (currentInterval / 2)) + currentTempo * 64);
+                    saveBaseData[name].push(Math.round((num - currentFirst) / (currentInterval / 2))
+                        + currentTempo * g_measure[g_paramObj.rhythm] * 4);
                     currentPos[name]++;
                 } else {
-                    const currentMaxPage = Math.ceil(saveBaseData[name][saveBaseData[name].length - 1]) / 64;
+                    const currentMaxPage = Math.ceil(saveBaseData[name][saveBaseData[name].length - 1]) / (g_measure[g_paramObj.rhythm] * 4);
                     if (currentMaxPage > maxPage) {
                         maxPage = currentMaxPage;
                     }
@@ -272,7 +292,7 @@ const calcPoint = (_names, _baseData) => {
                 }
             }
 
-            const currentMaxPage = Math.ceil(saveBaseData[name][saveBaseData[name].length - 1]) / 64;
+            const currentMaxPage = Math.ceil(saveBaseData[name][saveBaseData[name].length - 1]) / (g_measure[g_paramObj.rhythm] * 4);
             if (currentMaxPage > maxPage) {
                 maxPage = currentMaxPage;
             }
@@ -310,13 +330,13 @@ const printSaveData = {
             saveData += `&`;
         });
 
-        saveData += `${g_rootObj.ryhthm_num !== undefined ? g_rootObj.ryhthm_num : ''}&`;
+        saveData += `&`;
         saveData += `${g_paramObj.firstNums.join(',')}&`;
         saveData += `${g_paramObj.intervals.join(',')}&`;
         saveData += `${g_paramObj.tempos.join(',')}&`;
         saveData += `${_scoreNo}&`;
         saveData += `${g_paramObj.maxPage < 100 ? 100 : g_paramObj.maxPage}&`;
-        saveData += `16&2&`;
+        saveData += `${g_measure[g_paramObj.rhythm]}&${g_paramObj.rhythm}&`;
         saveData += `${g_rootObj.label_num !== undefined ? g_rootObj.label_num : '0'}&`;
 
         return saveData;

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,7 @@
 const g_version = `Ver 0.1.0`;
 
 let g_rootObj = {};
+let g_paramObj = {};
 const g_keyObj = {
 
     // キー別ヘッダー
@@ -141,7 +142,7 @@ const createBaseData = (_names, _scoreNo, _keyNum) => {
 
     let baseData = {};
     _names.forEach(name => {
-        if (g_rootObj[`${name}${_scoreNo}_data`] !== undefined) {
+        if (g_rootObj[`${name}${_scoreNo}_data`] !== undefined && g_rootObj[`${name}${_scoreNo}_data`] !== ``) {
             baseData[name] = (g_rootObj[`${name}${_scoreNo}_data`].split(`,`));
         }
     });
@@ -151,6 +152,60 @@ const createBaseData = (_names, _scoreNo, _keyNum) => {
         baseData.speed = g_rootObj[`speed${_scoreNo}_change`].split(`,`);
     }
     return baseData;
+}
+
+/**
+ * 最小値を取得
+ * @param {number} a 
+ * @param {number} b 
+ */
+const getMin = (a, b) => Math.min(a, b);
+
+/**
+ * 奇数番号の配列を取得
+ * @param {array} _array 
+ */
+const getOddArray = (_array) => _array.filter((value, i) => i % 2 === 0);
+
+/**
+ * ファーストナンバーの自動取得
+ * @param {array} _names 
+ * @param {object} _baseData 
+ */
+const getFirstNum = (_names, _baseData) => {
+
+    // speed, boostのみ速度データを抜き取り
+    const speeds = [`speed`, `boost`];
+    speeds.forEach(speed => {
+        if (_baseData[speed] !== undefined) {
+            _baseData[speed] = getOddArray(_baseData[speed]);
+        }
+    });
+
+    let minData = [];
+    _names.forEach(name => {
+        if (_baseData[name] !== undefined) {
+            minData.push(_baseData[name].reduce(getMin));
+        }
+    });
+    return minData.reduce(getMin);
+}
+
+/**
+ * 各種パラメーターの設定
+ * @param {array} _names 
+ * @param {object} _baseData 
+ * @param {string} _intervals 
+ */
+const setParameters = (_names, _baseData, _intervals) => {
+
+    const firstNums = document.getElementById(`firstNum`).value;
+    if (firstNums === ``) {
+        g_paramObj.firstNums = [getFirstNum(_names, _baseData)];
+    } else {
+        g_paramObj.firstNums = firstNums.split(`,`);
+    }
+    console.log(g_paramObj.firstNums);
 }
 
 /**
@@ -178,9 +233,10 @@ const makeSaveData = (_str) => {
 
     // 入力データを分解してオブジェクト化
     g_rootObj = rawDosToObject(_str);
-
     const baseData = createBaseData(keyNames, scoreNo, keyNum);
 
     console.log(baseData);
+
+    setParameters(keyNames, baseData, intervals);
 
 }

--- a/js/main.js
+++ b/js/main.js
@@ -52,7 +52,7 @@ const bpmToInterval = () => {
 
     let intervals = [];
     bpms.split(`,`).forEach(bpm => {
-        intervals.push(1800 / bpm);
+        intervals.push(Math.round(1800 / bpm * 10000) / 10000);
     });
     document.getElementById(`interval`).value = intervals.join(`,`);
     return intervals.join(`,`);
@@ -216,7 +216,7 @@ const setParameters = (_names, _baseData) => {
     document.getElementById(`interval`).value = g_paramObj.intervals.join(`,`);
 
     // BPMの取得
-    g_paramObj.bpms = g_paramObj.intervals.map(interval => 1800 / interval);
+    g_paramObj.bpms = g_paramObj.intervals.map(interval => Math.round((1800 / interval * 10000) / 10000));
     document.getElementById(`bpm`).value = g_paramObj.bpms.join(`,`);
 
     // テンポ変化位置の取得

--- a/js/main.js
+++ b/js/main.js
@@ -5,11 +5,11 @@
  *
  * Source by tickle
  * Created : 2020/09/09
- * Revised : 
+ * Revised : 2020/09/12
  *
  * https://github.com/cwtickle/danoniplus-reverser
  */
-const g_version = `Ver 0.1.0`;
+const g_version = `Ver 0.12.1`;
 
 let g_rootObj = {};
 let g_paramObj = {};
@@ -192,13 +192,15 @@ const createBaseData = (_names, _scoreNo, _keyNum) => {
 const getFirstNum = (_names, _baseData) => {
 
     let minData = [];
+    let dataExistFlg = false;
     const keyNames = _names.concat([`speedFrame`, `boostFrame`]);
     keyNames.forEach(name => {
         if (_baseData[name] !== undefined) {
             minData.push(_baseData[name].reduce(getMin));
+            dataExistFlg = true;
         }
     });
-    return minData.reduce(getMin);
+    return dataExistFlg ? minData.reduce(getMin) : 200;
 }
 
 /**
@@ -209,13 +211,15 @@ const getFirstNum = (_names, _baseData) => {
 const getLastNum = (_names, _baseData) => {
 
     let maxData = [];
+    let dataExistFlg = false;
     const keyNames = _names.concat([`speedFrame`, `boostFrame`]);
     keyNames.forEach(name => {
         if (_baseData[name] !== undefined) {
             maxData.push(_baseData[name].reduce(getMax));
+            dataExistFlg = true;
         }
     });
-    return maxData.reduce(getMax);
+    return dataExistFlg ? maxData.reduce(getMax) : 200;
 }
 
 /**
@@ -270,8 +274,6 @@ const setParameters = (_names, _baseData) => {
         g_paramObj.rhythm = rhythm;
     }
     document.getElementById(`rhythm`).value = g_paramObj.rhythm;
-
-    console.log(g_paramObj);
 }
 
 /**
@@ -324,7 +326,6 @@ const calcPoint = (_names, _baseData) => {
     });
     g_paramObj.maxPage = maxPage;
 
-    console.log(saveBaseData);
     return saveBaseData;
 
 }
@@ -531,7 +532,7 @@ const printSaveData = {
     fuji: (_keys, _names, _saveData, _baseData, _scoreNo) => {
 
         const majorKeysFlg = [`5`, `7`, `7i`, `9`, `11`].includes(_keys);
-        const lastNum = getLastNum(_names, _baseData);
+        const lastNum = getLastNum(_names, _saveData);
         let maxBar = Math.ceil((lastNum + 1) / g_measure[g_paramObj.rhythm]);
         if (maxBar < 120) {
             maxBar = 120;
@@ -564,6 +565,21 @@ const printSaveData = {
         let tmpLastNum = Math.round(g_paramObj.firstNums[lastn] * 10) + Math.round(lastNums[lastn] * 10);
         saveData += `${maxBar}/${tmpLastNum},\r\n`;
 
+        /*
+        // 3, 5, 7拍子対応 - コマスキップ処理が別途必要なため一時コメント化
+        const skipRhythm = {
+            3: [4, 1],
+            5: [12, 2],
+            7: [4, 2],
+        }
+        if (g_paramObj.rhythm !== 2) {
+            let tmpSkipData = [];
+            for (let j = 0; j < maxBar; j += skipRhythm[g_paramObj.rhythm][1]) {
+                tmpSkipData.push(`${j}/${skipRhythm[g_paramObj.rhythm][0]}`);
+            }
+            saveData += tmpSkipData.join(`,`);
+        }
+        */
         saveData += `\r\n;===以下譜面\r\n`;
 
         let editorData = ``;
@@ -607,8 +623,6 @@ const makeSaveData = (_str) => {
     // 入力データを分解してオブジェクト化
     g_rootObj = rawDosToObject(_str);
     const baseData = createBaseData(keyNames, scoreNo, keyNum);
-
-    console.log(baseData);
 
     // パラメーターの設定
     setParameters(keyNames, baseData);

--- a/js/main.js
+++ b/js/main.js
@@ -299,7 +299,7 @@ const printSaveData = {
             saveData += `&`;
         });
 
-        [`speed`, `boost`].forEach((name, i) => {
+        [`speed`, `boost`].forEach(name => {
             if (_saveData[`${name}Frame`] !== undefined) {
                 let speedPrintArray = [];
                 for (let k = 0; k < _saveData[`${name}Frame`].length; k++) {
@@ -323,7 +323,33 @@ const printSaveData = {
     },
 
     doyle: (_keys, _names, _saveData, _baseData, _scoreNo) => {
+        let saveData = `Dancing Onigiri Save Data`;
+        saveData += `&musicTitle=&artist=&artistUrl=&difName=Normal&speedlock=1&index=${_scoreNo}&keys=${_keys}`;
 
+        _names.forEach((name, i) => {
+
+            if (i < _names.length / 2) {
+                saveData += `&arrow_data(${i})=${_saveData[name] !== undefined ? _saveData[name].join(',') : ''}`;
+            } else {
+                saveData += `&frzarrow_data(${i - _names.length / 2})=${_saveData[name] !== undefined ? _saveData[name].join(',') : ''}`;
+            }
+        });
+
+        [`speed`, `boost`].forEach(name => {
+            if (_saveData[`${name}Frame`] !== undefined) {
+                let speedPrintArray = [];
+                for (let k = 0; k < _saveData[`${name}Frame`].length; k++) {
+                    speedPrintArray.push(`${_saveData[`${name}Frame`][k]},${_baseData[`${name}Dat`][k]}`);
+                }
+                saveData += `${speedPrintArray.join(',')}`;
+            }
+            saveData += `&`;
+        });
+
+        saveData += `&first_data=${g_paramObj.firstNums.join(',')}&interval_data=${g_paramObj.intervals.join(',')}`;
+        saveData += `&rhythmchange_data=&version=2.38&dosPath=&tuning=name`;
+
+        return saveData;
     },
 
     fuji: (_keys, _names, _saveData, _baseData, _scoreNo) => {

--- a/js/main.js
+++ b/js/main.js
@@ -21,30 +21,22 @@ const g_keyObj = {
     chara5_0: [`left`, `down`, `up`, `right`, `space`],
     chara7_0: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
     chara7i_0: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
-    chara8_0: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`, `sleft`],
-    chara9A_0: [`left`, `down`, `up`, `right`, `space`, `sleft`, `sdown`, `sup`, `sright`],
-    chara9B_0: [`left`, `down`, `up`, `right`, `space`, `sleft`, `sdown`, `sup`, `sright`],
-    chara9i_0: [`sleft`, `sdown`, `sup`, `sright`, `left`, `down`, `up`, `right`, `space`],
-    chara11_0: [`sleft`, `sdown`, `sup`, `sright`,
-        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
-    chara11L_0: [`sleft`, `sdown`, `sup`, `sright`,
-        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara9_0: [`left`, `down`, `up`, `right`, `space`, `sleft`, `sdown`, `sup`, `sright`],
+    chara11_0: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`,
+        `sleft`, `sdown`, `sup`, `sright`],
+
     chara11i_0: [`left`, `down`, `gor`, `up`, `right`, `space`,
         `sleft`, `sdown`, `siyo`, `sup`, `sright`],
-    chara11W_0: [`sleft`, `sdown`, `sup`, `sright`,
-        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
-    chara12_0: [`sleft`, `sdown`, `sup`, `sright`,
-        `oni`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
-    chara13_0: [`tleft`, `tdown`, `tup`, `tright`,
-        `left`, `down`, `up`, `right`, `space`, `sleft`, `sdown`, `sup`, `sright`],
+    chara12_0: [`oni`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`,
+        `sleft`, `sdown`, `sup`, `sright`],
+    chara13_0: [`left`, `down`, `up`, `right`, `space`, `sleft`, `sdown`, `sup`, `sright`,
+        `tleft`, `tdown`, `tup`, `tright`],
     chara14_0: [`sleftdia`, `sleft`, `sdown`, `sup`, `sright`, `srightdia`,
         `oni`, `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
     chara14i_0: [`gor`, `space`, `iyo`, `left`, `down`, `up`, `right`,
         `sleft`, `sleftdia`, `sdown`, `sspace`, `sup`, `srightdia`, `sright`],
-    chara15A_0: [`sleft`, `sdown`, `sup`, `sright`, `tleft`, `tdown`, `tup`, `tright`,
-        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
-    chara15B_0: [`sleft`, `sdown`, `sup`, `sright`, `tleft`, `tdown`, `tup`, `tright`,
-        `left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`],
+    chara15_0: [`left`, `leftdia`, `down`, `space`, `up`, `rightdia`, `right`,
+        `sleft`, `sdown`, `sup`, `sright`, `tleft`, `tdown`, `tup`, `tright`],
     chara16i_0: [`gor`, `space`, `iyo`, `left`, `down`, `up`, `right`,
         `sleft`, `sdown`, `sup`, `sright`, `aspace`, `aleft`, `adown`, `aup`, `aright`],
     chara17_0: [`aleft`, `bleft`, `adown`, `bdown`, `aup`, `bup`, `aright`, `bright`, `space`,
@@ -263,6 +255,8 @@ const calcPoint = (_names, _baseData) => {
             const currentFirst = g_paramObj.firstNums[j];
             const currentInterval = (g_paramObj.intervals[j] !== undefined ? g_paramObj.intervals[j] : 10);
             const currentTempo = (g_paramObj.tempos[j] !== undefined ? g_paramObj.tempos[j] : maxPage);
+            g_paramObj.intervals[j] = currentInterval;
+            g_paramObj.tempos[j] = currentTempo;
 
             for (let k = currentPos[name]; k < _baseData[name].length; k++) {
                 const num = _baseData[name][k];
@@ -284,10 +278,58 @@ const calcPoint = (_names, _baseData) => {
             }
         }
     });
+    g_paramObj.maxPage = maxPage;
 
     console.log(saveBaseData);
+    return saveBaseData;
 
 }
+
+/**
+ * セーブデータの出力処理
+ */
+const printSaveData = {
+
+    tickle: (_keys, _names, _saveData, _baseData, _scoreNo) => {
+        let saveData = `${_keys}/`;
+        _names.forEach(name => {
+            if (_saveData[name] !== undefined) {
+                saveData += `${_saveData[name].join(',')}`;
+            }
+            saveData += `&`;
+        });
+
+        [`speed`, `boost`].forEach((name, i) => {
+            if (_saveData[`${name}Frame`] !== undefined) {
+                let speedPrintArray = [];
+                for (let k = 0; k < _saveData[`${name}Frame`].length; k++) {
+                    speedPrintArray.push(`${_saveData[`${name}Frame`][k]}=${_baseData[`${name}Dat`][k]}`);
+                }
+                saveData += `${speedPrintArray.join(',')}`;
+            }
+            saveData += `&`;
+        });
+
+        saveData += `${g_rootObj.ryhthm_num !== undefined ? g_rootObj.ryhthm_num : ''}&`;
+        saveData += `${g_paramObj.firstNums.join(',')}&`;
+        saveData += `${g_paramObj.intervals.join(',')}&`;
+        saveData += `${g_paramObj.tempos.join(',')}&`;
+        saveData += `${_scoreNo}&`;
+        saveData += `${g_paramObj.maxPage < 100 ? 100 : g_paramObj.maxPage}&`;
+        saveData += `16&2&`;
+        saveData += `${g_rootObj.label_num !== undefined ? g_rootObj.label_num : '0'}&`;
+
+        return saveData;
+    },
+
+    doyle: (_keys, _names, _saveData, _baseData, _scoreNo) => {
+
+    },
+
+    fuji: (_keys, _names, _saveData, _baseData, _scoreNo) => {
+
+    },
+};
 
 /**
  * セーブデータ生成処理（メイン）
@@ -312,8 +354,13 @@ const makeSaveData = (_str) => {
 
     console.log(baseData);
 
+    // パラメーターの設定
     setParameters(keyNames, baseData);
 
-    calcPoint(keyNames, baseData);
+    // エディター上の位置を計算
+    const saveBaseData = calcPoint(keyNames, baseData);
+
+    const editorPtn = document.getElementById(`editor`).value;
+    return printSaveData[editorPtn](keyLabel, keyNames, saveBaseData, baseData, scoreNo);
 
 }


### PR DESCRIPTION
## 🛠️ タスク
- ✔️ 画面の外装
- ✔️ 矢印名からフリーズアロー名への変換
- ✔️ 入力データを分解して名称別のオブジェクトへ変換
- ✔️ ファーストナンバーの自動算出、補完処理
- ✔️ BPMからInterval（4分間隔）の変換処理
- ➖ テンポ変化情報による逆変換処理
  - ✔️ 4拍子、16分までのデータ丸め処理
  - ➖ それ以外のパターン
- ✔️ 出力データ整形
  - ✔️ tickle (Cross Walker)エディター
  - ✔️ doyle (SPEED START)エディター
  - ✔️ FUJI(気分転換にRPG)エディター / Ver2版
  - ✔️ FUJI(気分転換にRPG)エディター / Nkey版

## 📷 スクリーンショット
- 開発中のものです。画面レイアウト・構成は今後変更する可能性があります。
<img src="https://user-images.githubusercontent.com/44026291/92819725-135b0480-f404-11ea-9d53-bce12f2afa99.png" width="70%">


## 📝 その他コメント
- ヘッダー、フッター対応は後回しとする。（必須を除いて基本対応しない予定）
- CW Edition対応のエディターはセーブデータ未解析のため、初期実装には含めない予定。
- 現状は譜面データからセーブデータへの変換のみとなっているが、
将来的にセーブデータ間の変換も視野に検討する。